### PR TITLE
feat: add beta distribution to sample probabilities in thompson sampling

### DIFF
--- a/api/distributed/fedadapruning/FedAdaPruningServerManager.py
+++ b/api/distributed/fedadapruning/FedAdaPruningServerManager.py
@@ -27,9 +27,9 @@ class FedAdaPruningServerManager(ServerManager):
         self.mode = 0 
 
         # adaptive related
-        self.weight_beta = 0.8
+        self.weight_beta = args.adaptive_beta
         self.weight_momentum = None
-        self.gradient_beta = 0.8
+        self.gradient_beta = args.adaptive_beta
         self.gradient_momentum = None
 
         # mode 0, the server send both weight and mask to clients, received the weight, perform weight aggregation, if t % \delta t == 0 and t <= t_end, go to mode 2, else, go to mode 1

--- a/experiments/distributed/fedadapruning/README.MD
+++ b/experiments/distributed/fedadapruning/README.MD
@@ -6,7 +6,7 @@ CUDA_VISIBLE_DEVICES=0,1,2,3 sh run_fedadapruning_distributed_pytorch.sh resnet1
 # --adjustment_epochs None --growth_data_mode batch --client_optimizer adam
 
 # quick test 
-CUDA_VISIBLE_DEVICES=0,1,2,3 sh run_fedadapruning_distributed_pytorch.sh resnet18 cifar10 100 10 500 1 0.1 0.1 --delta_T 10 --T_end 300 --num_eval 128 --frequency_of_the_test 10 --enable_adaptive_aggregation 0 --enable_ts 1 --aggregated_gamma 1.0
+CUDA_VISIBLE_DEVICES=0,1,2,3 sh run_fedadapruning_distributed_pytorch.sh resnet18 cifar10 100 10 500 1 0.1 0.1 --delta_T 10 --T_end 300 --num_eval 128 --frequency_of_the_test 10 --enable_adaptive_aggregation 0 --adaptive_beta 0.1 --enable_ts 1 --aggregated_gamma 1.0 --initial_distribution_ratio 1.0
 # --adjustment_epochs None --growth_data_mode batch --client_optimizer sgd
 ```
 
@@ -20,7 +20,7 @@ CUDA_VISIBLE_DEVICES=0,1,2,3 sh run_fedadapruning_distributed_pytorch.sh gpt2 ti
 ## Usage
 [$\cdot$] is mandatory arguments, {$\cdot$} is the optional arguments.
 ```
-CUDA_VISIBLE_DEVICES=[gpus] sh run_fedadapruning_distributed_pytorch.sh [model] [dataset] [client_num_in_total] [client_num_per_round]  [comm_round] [epochs] [target_density] [initial_lr]   {--delta_T , --T_end, --partition_alpha, --num_eval, --frequency_of_the_test, --enable_adaptive_aggregation, --enable_ts, --aggregated_gamma}
+CUDA_VISIBLE_DEVICES=[gpus] sh run_fedadapruning_distributed_pytorch.sh [model] [dataset] [client_num_in_total] [client_num_per_round]  [comm_round] [epochs] [target_density] [initial_lr]   {--delta_T , --T_end, --partition_alpha, --num_eval, --frequency_of_the_test, --enable_adaptive_aggregation, --adaptive_beta, --enable_ts, --aggregated_gamma, --initial_distribution_ratio}
 ```
 
 where
@@ -40,6 +40,8 @@ where
 {--partition_alpha} refers to the partition alpha, higher partition alpha makes lower degree of data heterogeneity
 {--num_eval}is the number data samples for validation, -1 means using the whole testing dataset.
 {--frequency_of_the_test} the frequency to test/validate the performance during the training, using num_eval data samples[enable_adaptive_aggregation] whether use adaptive method(momentum) on server to update gradients
+[adaptive_beta] beta for adaptive method such as momentum
 [enable_ts] whether use ts when pruning and growing on server
-[aggregated_gamma] the weight for aggregated parameters' voting("1 - gamma" for clients' parameters)
+[aggregated_gamma] the weight for aggregated parameters' voting("1 - gamma" for clients' parameters
+[initial_distribution_ratio] ratio for initial beta distribution in thompson sampling
 ```

--- a/experiments/distributed/fedadapruning/main_fedadapruning.py
+++ b/experiments/distributed/fedadapruning/main_fedadapruning.py
@@ -100,9 +100,13 @@ def add_args(parser):
 
     parser.add_argument("--enable_adaptive_aggregation", type=int, default=0, help="use adaptive method")
 
+    parser.add_argument("--adaptive_beta", type=float, default=0.1, help="beta for momentum in aggregation")
+
     parser.add_argument("--enable_ts", type=int, default=0, help="use thompson sampling")
 
     parser.add_argument("--aggregated_gamma", type=float, default=1.0, help="weight for aggregated param")
+
+    parser.add_argument("--initial_distribution_ratio", type=float, default=1.0, help="ratio for initial beta distribution")
 
     # Following arguments are seldom changed
     parser.add_argument(


### PR DESCRIPTION
feat: 
1. add beta distribution for thompson sampling and sample the probabilities instead of using average of distribution
2. add two hyperparameters for test and adjustment
* adaptive_beta: beta for momentum, default is 0.1
* initial_distribution_ratio: ratio for initial distribution, default is 1.0, its decrease can increase the weight of voting when updating the beta  distribution

TODO: add history information to prune and grow (update beta distribution in each round's weight aggregation)