### PR TITLE
Add DWNP: device-wise federated network pruning method for federated learning

### DIFF
--- a/api/distributed/dwnp/DWNPAPI.py
+++ b/api/distributed/dwnp/DWNPAPI.py
@@ -1,0 +1,155 @@
+from mpi4py import MPI
+
+from .DWNPAggregator import DWNPAggregator
+from .DWNPTrainer import DWNPTrainer
+from .DWNPClientManager import DWNPClientManager
+from .DWNPServerManager import DWNPServerManager
+
+from .my_model_trainer_classification import MyModelTrainer as MyModelTrainerCLS
+from .my_model_trainer_language_model import MyModelTrainer as MyModelTrainerLM
+
+
+def FedML_init():
+    comm = MPI.COMM_WORLD
+    process_id = comm.Get_rank()
+    worker_number = comm.Get_size()
+    return comm, process_id, worker_number
+
+
+def FedML_DWNP_distributed(
+    process_id,
+    worker_number,
+    device,
+    comm,
+    model,
+    train_data_num,
+    train_data_global,
+    test_data_global,
+    train_data_local_num_dict,
+    train_data_local_dict,
+    test_data_local_dict,
+    args,
+    model_trainer=None,
+    preprocessed_sampling_lists=None,
+):
+    if process_id == 0:
+        init_server(
+            args,
+            device,
+            comm,
+            process_id,
+            worker_number,
+            model,
+            train_data_num,
+            train_data_global,
+            test_data_global,
+            train_data_local_dict,
+            test_data_local_dict,
+            train_data_local_num_dict,
+            model_trainer,
+            preprocessed_sampling_lists,
+        )
+    else:
+        init_client(
+            args,
+            device,
+            comm,
+            process_id,
+            worker_number,
+            model,
+            train_data_num,
+            train_data_local_num_dict,
+            train_data_local_dict,
+            test_data_local_dict,
+            model_trainer,
+        )
+
+
+def init_server(
+    args,
+    device,
+    comm,
+    rank,
+    size,
+    model,
+    train_data_num,
+    train_data_global,
+    test_data_global,
+    train_data_local_dict,
+    test_data_local_dict,
+    train_data_local_num_dict,
+    model_trainer,
+    preprocessed_sampling_lists=None,
+):
+    if model_trainer is None:
+        if args.dataset in ["tinystories"]:
+            model_trainer = MyModelTrainerLM(model, args)
+        else:
+            model_trainer = MyModelTrainerCLS(model, args)
+    model_trainer.set_id(-1)
+
+    worker_num = size - 1
+    aggregator = DWNPAggregator(
+        train_data_global,
+        test_data_global,
+        train_data_num,
+        train_data_local_dict,
+        test_data_local_dict,
+        train_data_local_num_dict,
+        worker_num,
+        device,
+        args,
+        model_trainer,
+    )
+
+    backend = args.backend
+    if preprocessed_sampling_lists is None:
+        server_manager = DWNPServerManager(args, aggregator, comm, rank, size, backend)
+    else:
+        server_manager = DWNPServerManager(
+            args,
+            aggregator,
+            comm,
+            rank,
+            size,
+            backend,
+            is_preprocessed=True,
+            preprocessed_client_lists=preprocessed_sampling_lists,
+        )
+    server_manager.send_init_msg()
+    server_manager.run()
+
+
+def init_client(
+    args,
+    device,
+    comm,
+    process_id,
+    size,
+    model,
+    train_data_num,
+    train_data_local_num_dict,
+    train_data_local_dict,
+    test_data_local_dict,
+    model_trainer=None,
+):
+    client_index = process_id - 1
+    if model_trainer is None:
+        if args.dataset in ["tinystories"]:
+            model_trainer = MyModelTrainerLM(model, args)
+        else:
+            model_trainer = MyModelTrainerCLS(model, args)
+    model_trainer.set_id(client_index)
+
+    trainer = DWNPTrainer(
+        client_index,
+        train_data_local_dict,
+        train_data_local_num_dict,
+        test_data_local_dict,
+        train_data_num,
+        device,
+        args,
+        model_trainer,
+    )
+    client_manager = DWNPClientManager(args, trainer, comm, process_id, size, args.backend)
+    client_manager.run()

--- a/api/distributed/dwnp/DWNPAggregator.py
+++ b/api/distributed/dwnp/DWNPAggregator.py
@@ -1,0 +1,218 @@
+import logging
+import random
+import time
+
+import numpy as np
+import torch
+import wandb
+
+from .utils import transform_list_to_tensor
+
+
+class DWNPAggregator(object):
+    def __init__(
+        self,
+        train_global,
+        test_global,
+        all_train_data_num,
+        train_data_local_dict,
+        test_data_local_dict,
+        train_data_local_num_dict,
+        worker_num,
+        device,
+        args,
+        model_trainer,
+    ):
+        self.trainer = model_trainer
+
+        self.args = args
+        self.train_global = train_global
+        self.test_global = test_global
+        self.val_global = self._generate_validation_set(self.args.num_eval)
+        self.all_train_data_num = all_train_data_num
+
+        self.train_data_local_dict = train_data_local_dict
+        self.test_data_local_dict = test_data_local_dict
+        self.train_data_local_num_dict = train_data_local_num_dict
+
+        self.worker_num = worker_num
+        self.device = device
+
+        self.model_dict = dict()
+        self.hn_params_dict = dict()
+        self.emb_params_dict = dict()
+        self.sample_num_dict = dict()
+
+        self.flag_client_uploaded_dict = dict()
+        for idx in range(self.worker_num):
+            self.flag_client_uploaded_dict[idx] = False
+
+    def get_global_model_params(self):
+        return self.trainer.get_model_params()
+
+    def set_global_model_params(self, model_parameters):
+        self.trainer.set_model_params(model_parameters)
+
+    def get_global_hn_params(self):
+        return self.trainer.get_hypernet_params()
+
+    def set_global_hn_params(self, hn_parameters):
+        self.trainer.set_hypernet_params(hn_parameters)
+
+    def get_global_emb_params(self):
+        return self.trainer.get_dynamic_emb_params()
+
+    def set_global_emb_params(self, emb_parameters):
+        self.trainer.set_dynamic_emb_params(emb_parameters)
+
+    def prepare_final_pruned_model(self, round_idx=None):
+        server_mask = self.trainer.apply_server_pruning(self.device, round_idx=round_idx)
+        self.set_global_model_params(self.trainer.get_model_params())
+        return self.get_global_model_params()
+
+    def add_local_trained_result(
+        self,
+        worker_index,
+        client_index,
+        model_params,
+        sample_num,
+        hn_params=None,
+        emb_params=None,
+    ):
+        logging.info("add_model worker=%d client=%d", worker_index, client_index)
+        self.model_dict[client_index] = model_params
+        self.sample_num_dict[client_index] = sample_num
+        if hn_params is not None:
+            self.hn_params_dict[client_index] = hn_params
+        if emb_params is not None:
+            self.emb_params_dict[client_index] = emb_params
+        self.flag_client_uploaded_dict[worker_index] = True
+
+    def check_whether_all_receive(self):
+        for idx in range(self.worker_num):
+            if not self.flag_client_uploaded_dict[idx]:
+                return False
+        for idx in range(self.worker_num):
+            self.flag_client_uploaded_dict[idx] = False
+        return True
+
+    def aggregate_models(self):
+        start_time = time.time()
+        model_list = []
+        training_num = 0
+
+        for idx in self.model_dict.keys():
+            if self.args.is_mobile == 1:
+                self.model_dict[idx] = transform_list_to_tensor(self.model_dict[idx])
+            model_list.append((self.sample_num_dict[idx], self.model_dict[idx]))
+            training_num += self.sample_num_dict[idx]
+
+        (num0, averaged_params) = model_list[0]
+        for k in averaged_params.keys():
+            for i in range(len(model_list)):
+                local_sample_number, local_model_params = model_list[i]
+                w = local_sample_number / training_num
+                if i == 0:
+                    averaged_params[k] = local_model_params[k] * w
+                else:
+                    averaged_params[k] += local_model_params[k] * w
+
+        self.set_global_model_params(averaged_params)
+        self.model_dict = dict()
+
+        logging.info("aggregate model time cost: %.3f", time.time() - start_time)
+        return averaged_params
+
+    def aggregate_hypernet(self):
+        if len(self.hn_params_dict) == 0:
+            return self.get_global_hn_params()
+
+        start_time = time.time()
+        hn_list = []
+        training_num = 0
+
+        for idx in self.hn_params_dict.keys():
+            local_hn = self.hn_params_dict[idx]
+            if self.args.is_mobile == 1:
+                local_hn = transform_list_to_tensor(local_hn)
+            hn_list.append((self.sample_num_dict[idx], local_hn))
+            training_num += self.sample_num_dict[idx]
+
+        (_, averaged_hn) = hn_list[0]
+        for k in averaged_hn.keys():
+            for i in range(len(hn_list)):
+                local_sample_number, local_hn = hn_list[i]
+                w = local_sample_number / training_num
+                if i == 0:
+                    averaged_hn[k] = local_hn[k] * w
+                else:
+                    averaged_hn[k] += local_hn[k] * w
+
+        self.set_global_hn_params(averaged_hn)
+        self.hn_params_dict = dict()
+
+        logging.info("aggregate hypernet time cost: %.3f", time.time() - start_time)
+        return averaged_hn
+
+    def aggregate_dynamic_emb(self):
+        if len(self.emb_params_dict) == 0:
+            return self.get_global_emb_params()
+
+        start_time = time.time()
+        emb_list = []
+        training_num = 0
+
+        for idx in self.emb_params_dict.keys():
+            local_emb = self.emb_params_dict[idx]
+            if self.args.is_mobile == 1:
+                local_emb = transform_list_to_tensor(local_emb)
+            emb_list.append((self.sample_num_dict[idx], local_emb))
+            training_num += self.sample_num_dict[idx]
+
+        (_, averaged_emb) = emb_list[0]
+        for k in averaged_emb.keys():
+            for i in range(len(emb_list)):
+                local_sample_number, local_emb = emb_list[i]
+                w = local_sample_number / training_num
+                if i == 0:
+                    averaged_emb[k] = local_emb[k] * w
+                else:
+                    averaged_emb[k] += local_emb[k] * w
+
+        self.set_global_emb_params(averaged_emb)
+        self.emb_params_dict = dict()
+
+        logging.info("aggregate dynamic emb time cost: %.3f", time.time() - start_time)
+        return averaged_emb
+
+    def client_sampling(self, round_idx, client_num_in_total, client_num_per_round):
+        if client_num_in_total == client_num_per_round:
+            client_indexes = [client_index for client_index in range(client_num_in_total)]
+        else:
+            num_clients = min(client_num_per_round, client_num_in_total)
+            np.random.seed(round_idx)
+            client_indexes = np.random.choice(range(client_num_in_total), num_clients, replace=False)
+        logging.info("client_indexes = %s", str(client_indexes))
+        return client_indexes
+
+    def _generate_validation_set(self, num_samples=10000):
+        if num_samples != -1:
+            test_data_num = len(self.test_global.dataset)
+            sample_indices = random.sample(range(test_data_num), min(num_samples, test_data_num))
+            subset = torch.utils.data.Subset(self.test_global.dataset, sample_indices)
+            sample_testset = torch.utils.data.DataLoader(subset, batch_size=self.args.batch_size)
+            return sample_testset
+        return self.test_global
+
+    def test_on_server_for_all_clients(self, round_idx):
+        if round_idx % self.args.frequency_of_the_test == 0 or round_idx >= self.args.comm_round - 10:
+            logging.info("################test_on_server_for_all_clients : %s", str(round_idx))
+            if round_idx >= self.args.comm_round - 10 or self.args.num_eval == -1:
+                metrics = self.trainer.test(self.test_global, self.device, self.args)
+            else:
+                metrics = self.trainer.test(self.val_global, self.device, self.args)
+
+            for key in metrics:
+                if key != "test_total":
+                    wandb.log({f"Test/{key}": metrics[key], "round": round_idx})
+            logging.info(metrics)

--- a/api/distributed/dwnp/DWNPClientManager.py
+++ b/api/distributed/dwnp/DWNPClientManager.py
@@ -1,0 +1,113 @@
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.getcwd(), "../../../")))
+
+try:
+    from core.distributed.client.client_manager import ClientManager
+    from core.distributed.communication.message import Message
+except ImportError:
+    from FedPruning.core.distributed.client.client_manager import ClientManager
+    from FedPruning.core.distributed.communication.message import Message
+
+from .message_define import MyMessage
+from .utils import transform_list_to_tensor
+
+
+class DWNPClientManager(ClientManager):
+    def __init__(self, args, trainer, comm=None, rank=0, size=0, backend="MPI"):
+        super().__init__(args, comm, rank, size, backend)
+        self.trainer = trainer
+        self.num_rounds = args.comm_round
+        self.round_idx = 0
+        self.current_client_index = -1
+
+    def run(self):
+        super().run()
+
+    def register_message_receive_handlers(self):
+        self.register_message_receive_handler(
+            MyMessage.MSG_TYPE_S2C_INIT_CONFIG,
+            self.handle_message_init,
+        )
+        self.register_message_receive_handler(
+            MyMessage.MSG_TYPE_S2C_SYNC_MODEL_TO_CLIENT,
+            self.handle_message_receive_model_from_server,
+        )
+
+    def handle_message_init(self, msg_params):
+        self._handle_server_message(msg_params, init=True)
+
+    def handle_message_receive_model_from_server(self, msg_params):
+        logging.info("handle_message_receive_model_from_server")
+        self._handle_server_message(msg_params, init=False)
+
+    def _handle_server_message(self, msg_params, init=False):
+        model_params = msg_params.get(MyMessage.MSG_ARG_KEY_MODEL_PARAMS)
+        hn_params = msg_params.get(MyMessage.MSG_ARG_KEY_HN_PARAMS)
+        emb_params = msg_params.get(MyMessage.MSG_ARG_KEY_EMB_PARAMS)
+
+        client_index = int(msg_params.get(MyMessage.MSG_ARG_KEY_CLIENT_INDEX))
+        round_idx = int(msg_params.get(MyMessage.MSG_ARG_KEY_ROUND_IDX))
+        sync_w = bool(msg_params.get(MyMessage.MSG_ARG_KEY_SYNC_W))
+        train_hn = bool(msg_params.get(MyMessage.MSG_ARG_KEY_TRAIN_HN))
+        sync_hn = bool(msg_params.get(MyMessage.MSG_ARG_KEY_SYNC_HN))
+
+        if self.args.is_mobile == 1:
+            model_params = transform_list_to_tensor(model_params)
+            hn_params = transform_list_to_tensor(hn_params)
+            emb_params = transform_list_to_tensor(emb_params)
+
+        client_changed = client_index != self.current_client_index
+        self.current_client_index = client_index
+        self.round_idx = round_idx
+
+        if init or sync_w or client_changed:
+            self.trainer.update_model(model_params)
+
+        if init or sync_hn:
+            self.trainer.update_hypernet(hn_params)
+            self.trainer.update_dynamic_emb(emb_params)
+
+        self.trainer.update_dataset(client_index)
+        self.__train(train_hn)
+
+        if self.round_idx == self.num_rounds:
+            self.finish()
+
+    def send_result_to_server(
+        self,
+        receive_id,
+        weights,
+        local_sample_num,
+        hn_params,
+        emb_params,
+        server_density,
+        device_density,
+    ):
+        message = Message(MyMessage.MSG_TYPE_C2S_SEND_RESULT_TO_SERVER, self.get_sender_id(), receive_id)
+        message.add_params(MyMessage.MSG_ARG_KEY_MODEL_PARAMS, weights)
+        message.add_params(MyMessage.MSG_ARG_KEY_CLIENT_INDEX, self.current_client_index)
+        message.add_params(MyMessage.MSG_ARG_KEY_NUM_SAMPLES, local_sample_num)
+        message.add_params(MyMessage.MSG_ARG_KEY_SERVER_DENSITY, server_density)
+        message.add_params(MyMessage.MSG_ARG_KEY_DEVICE_DENSITY, device_density)
+        message.add_params(MyMessage.MSG_ARG_KEY_HN_PARAMS, hn_params)
+        message.add_params(MyMessage.MSG_ARG_KEY_EMB_PARAMS, emb_params)
+        self.send_message(message)
+
+    def __train(self, train_hn):
+        logging.info("#######training########### round_id = %d", self.round_idx)
+        weights, hn_params, emb_params, local_sample_num, server_density, device_density = self.trainer.train(
+            round_idx=self.round_idx,
+            train_hn=train_hn,
+        )
+        self.send_result_to_server(
+            0,
+            weights,
+            local_sample_num,
+            hn_params,
+            emb_params,
+            server_density,
+            device_density,
+        )

--- a/api/distributed/dwnp/DWNPServerManager.py
+++ b/api/distributed/dwnp/DWNPServerManager.py
@@ -1,0 +1,226 @@
+import logging
+import os
+import sys
+
+from .message_define import MyMessage
+from .utils import transform_tensor_to_list
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.getcwd(), "../../../")))
+try:
+    from core.distributed.communication.message import Message
+    from core.distributed.server.server_manager import ServerManager
+except ImportError:
+    from FedPruning.core.distributed.communication.message import Message
+    from FedPruning.core.distributed.server.server_manager import ServerManager
+
+
+class DWNPServerManager(ServerManager):
+    def __init__(
+        self,
+        args,
+        aggregator,
+        comm=None,
+        rank=0,
+        size=0,
+        backend="MPI",
+        is_preprocessed=False,
+        preprocessed_client_lists=None,
+    ):
+        super().__init__(args, comm, rank, size, backend)
+        self.args = args
+        self.aggregator = aggregator
+        self.round_num = args.comm_round
+        self.round_idx = 0
+
+        self.hn_update_steps = 0
+        self.final_prune_applied = False
+
+        self.is_preprocessed = is_preprocessed
+        self.preprocessed_client_lists = preprocessed_client_lists
+
+    def run(self):
+        super().run()
+
+    def _flags_for_round(self, round_idx):
+        if getattr(self.args, "dwnp_enable_final_prune", 1) and round_idx == self.args.comm_round:
+            return True, False, False
+
+        sync_w = (round_idx % self.args.r_w == 0)
+        train_hn = (round_idx % self.args.r_hn == 0)
+        if train_hn:
+            next_hn_step = self.hn_update_steps + 1
+            sync_hn = (next_hn_step % self.args.r_theta == 0)
+        else:
+            sync_hn = False
+        return sync_w, train_hn, sync_hn
+
+    def send_init_msg(self):
+        client_indexes = self.aggregator.client_sampling(
+            self.round_idx,
+            self.args.client_num_in_total,
+            self.args.client_num_per_round,
+        )
+
+        global_model_params = self.aggregator.get_global_model_params()
+        global_hn_params = self.aggregator.get_global_hn_params()
+        global_emb_params = self.aggregator.get_global_emb_params()
+        if self.args.is_mobile == 1:
+            global_model_params = transform_tensor_to_list(global_model_params)
+            global_hn_params = transform_tensor_to_list(global_hn_params)
+            global_emb_params = transform_tensor_to_list(global_emb_params)
+
+        sync_w, train_hn, sync_hn = self._flags_for_round(self.round_idx)
+
+        for process_id in range(1, self.size):
+            self.send_message_init_config(
+                process_id,
+                global_model_params,
+                global_hn_params,
+                global_emb_params,
+                client_indexes[process_id - 1],
+                self.round_idx,
+                sync_w,
+                train_hn,
+                sync_hn,
+            )
+
+    def register_message_receive_handlers(self):
+        self.register_message_receive_handler(
+            MyMessage.MSG_TYPE_C2S_SEND_RESULT_TO_SERVER,
+            self.handle_message_receive_model_from_client,
+        )
+
+    def handle_message_receive_model_from_client(self, msg_params):
+        sender_id = msg_params.get(MyMessage.MSG_ARG_KEY_SENDER)
+        model_params = msg_params.get(MyMessage.MSG_ARG_KEY_MODEL_PARAMS)
+        local_sample_number = msg_params.get(MyMessage.MSG_ARG_KEY_NUM_SAMPLES)
+        client_index = int(msg_params.get(MyMessage.MSG_ARG_KEY_CLIENT_INDEX))
+
+        hn_params = msg_params.get(MyMessage.MSG_ARG_KEY_HN_PARAMS)
+        emb_params = msg_params.get(MyMessage.MSG_ARG_KEY_EMB_PARAMS)
+
+        self.aggregator.add_local_trained_result(
+            sender_id - 1,
+            client_index,
+            model_params,
+            local_sample_number,
+            hn_params,
+            emb_params,
+        )
+
+        if not self.aggregator.check_whether_all_receive():
+            return
+
+        sync_w, train_hn, sync_hn = self._flags_for_round(self.round_idx)
+
+        if sync_w:
+            global_model_params = self.aggregator.aggregate_models()
+        else:
+            self.aggregator.model_dict = dict()
+            global_model_params = self.aggregator.get_global_model_params()
+
+        if train_hn:
+            self.hn_update_steps += 1
+            if sync_hn:
+                global_hn_params = self.aggregator.aggregate_hypernet()
+                global_emb_params = self.aggregator.aggregate_dynamic_emb()
+            else:
+                self.aggregator.hn_params_dict = dict()
+                self.aggregator.emb_params_dict = dict()
+                global_hn_params = self.aggregator.get_global_hn_params()
+                global_emb_params = self.aggregator.get_global_emb_params()
+        else:
+            self.aggregator.hn_params_dict = dict()
+            self.aggregator.emb_params_dict = dict()
+            global_hn_params = self.aggregator.get_global_hn_params()
+            global_emb_params = self.aggregator.get_global_emb_params()
+
+        self.aggregator.test_on_server_for_all_clients(self.round_idx)
+
+        self.round_idx += 1
+        if self.round_idx == self.round_num + 1:
+            self.finish()
+            return
+
+        if getattr(self.args, "dwnp_enable_final_prune", 1) and self.round_idx == self.args.comm_round and not self.final_prune_applied:
+            global_model_params = self.aggregator.prepare_final_pruned_model(self.round_idx)
+            self.final_prune_applied = True
+
+        if self.is_preprocessed:
+            if self.preprocessed_client_lists is None:
+                client_indexes = [self.round_idx] * self.args.client_num_per_round
+            else:
+                client_indexes = self.preprocessed_client_lists[self.round_idx]
+        else:
+            client_indexes = self.aggregator.client_sampling(
+                self.round_idx,
+                self.args.client_num_in_total,
+                self.args.client_num_per_round,
+            )
+
+        sync_w, train_hn, sync_hn = self._flags_for_round(self.round_idx)
+
+        if self.args.is_mobile == 1:
+            global_model_params = transform_tensor_to_list(global_model_params)
+            global_hn_params = transform_tensor_to_list(global_hn_params)
+            global_emb_params = transform_tensor_to_list(global_emb_params)
+
+        for receiver_id in range(1, self.size):
+            self.send_message_sync_model_to_client(
+                receiver_id,
+                global_model_params,
+                global_hn_params,
+                global_emb_params,
+                client_indexes[receiver_id - 1],
+                self.round_idx,
+                sync_w,
+                train_hn,
+                sync_hn,
+            )
+
+    def send_message_init_config(
+        self,
+        receive_id,
+        global_model_params,
+        global_hn_params,
+        global_emb_params,
+        client_index,
+        round_idx,
+        sync_w,
+        train_hn,
+        sync_hn,
+    ):
+        message = Message(MyMessage.MSG_TYPE_S2C_INIT_CONFIG, self.get_sender_id(), receive_id)
+        message.add_params(MyMessage.MSG_ARG_KEY_MODEL_PARAMS, global_model_params)
+        message.add_params(MyMessage.MSG_ARG_KEY_HN_PARAMS, global_hn_params)
+        message.add_params(MyMessage.MSG_ARG_KEY_EMB_PARAMS, global_emb_params)
+        message.add_params(MyMessage.MSG_ARG_KEY_CLIENT_INDEX, str(client_index))
+        message.add_params(MyMessage.MSG_ARG_KEY_ROUND_IDX, round_idx)
+        message.add_params(MyMessage.MSG_ARG_KEY_SYNC_W, sync_w)
+        message.add_params(MyMessage.MSG_ARG_KEY_TRAIN_HN, train_hn)
+        message.add_params(MyMessage.MSG_ARG_KEY_SYNC_HN, sync_hn)
+        self.send_message(message)
+
+    def send_message_sync_model_to_client(
+        self,
+        receive_id,
+        global_model_params,
+        global_hn_params,
+        global_emb_params,
+        client_index,
+        round_idx,
+        sync_w,
+        train_hn,
+        sync_hn,
+    ):
+        logging.info("send_message_sync_model_to_client. receive_id = %d", receive_id)
+        message = Message(MyMessage.MSG_TYPE_S2C_SYNC_MODEL_TO_CLIENT, self.get_sender_id(), receive_id)
+        message.add_params(MyMessage.MSG_ARG_KEY_MODEL_PARAMS, global_model_params)
+        message.add_params(MyMessage.MSG_ARG_KEY_HN_PARAMS, global_hn_params)
+        message.add_params(MyMessage.MSG_ARG_KEY_EMB_PARAMS, global_emb_params)
+        message.add_params(MyMessage.MSG_ARG_KEY_CLIENT_INDEX, str(client_index))
+        message.add_params(MyMessage.MSG_ARG_KEY_ROUND_IDX, round_idx)
+        message.add_params(MyMessage.MSG_ARG_KEY_SYNC_W, sync_w)
+        message.add_params(MyMessage.MSG_ARG_KEY_TRAIN_HN, train_hn)
+        message.add_params(MyMessage.MSG_ARG_KEY_SYNC_HN, sync_hn)
+        self.send_message(message)

--- a/api/distributed/dwnp/DWNPTrainer.py
+++ b/api/distributed/dwnp/DWNPTrainer.py
@@ -1,0 +1,74 @@
+from .utils import transform_tensor_to_list
+
+
+class DWNPTrainer(object):
+    def __init__(
+        self,
+        client_index,
+        train_data_local_dict,
+        train_data_local_num_dict,
+        test_data_local_dict,
+        train_data_num,
+        device,
+        args,
+        model_trainer,
+    ):
+        self.trainer = model_trainer
+
+        self.client_index = client_index
+        self.train_data_local_dict = train_data_local_dict
+        self.train_data_local_num_dict = train_data_local_num_dict
+        self.test_data_local_dict = test_data_local_dict
+        self.all_train_data_num = train_data_num
+        self.train_local = None
+        self.local_sample_number = None
+        self.test_local = None
+
+        self.device = device
+        self.args = args
+        self._last_emb_params = None
+
+    def update_model(self, weights):
+        self.trainer.set_model_params(weights)
+
+    def update_hypernet(self, hn_params):
+        self.trainer.set_hypernet_params(hn_params)
+
+    def get_hypernet_params(self):
+        return self.trainer.get_hypernet_params()
+
+    def update_dynamic_emb(self, emb_params):
+        self.trainer.set_dynamic_emb_params(emb_params)
+
+    def get_dynamic_emb_params(self):
+        return self.trainer.get_dynamic_emb_params()
+
+    def update_dataset(self, client_index):
+        self.client_index = client_index
+        self.train_local = self.train_data_local_dict[client_index]
+        self.local_sample_number = self.train_data_local_num_dict[client_index]
+
+    def train(self, round_idx=None, train_hn=False):
+        self.args.round_idx = round_idx
+        server_density, device_density = self.trainer.prepare_joint_mask(
+            self.client_index,
+            round_idx,
+            self.device,
+            self.args,
+        )
+        self.trainer.train(self.train_local, self.device, self.args)
+
+        if train_hn:
+            self.trainer.train_hypernetwork(self.train_local, self.client_index, self.device, self.args)
+
+        weights = self.trainer.get_model_params()
+        hn_params = self.trainer.get_hypernet_params()
+        emb_params = self.trainer.get_dynamic_emb_params()
+        self._last_emb_params = emb_params
+
+        if self.args.is_mobile == 1:
+            weights = transform_tensor_to_list(weights)
+            hn_params = transform_tensor_to_list(hn_params)
+            emb_params = transform_tensor_to_list(emb_params)
+
+        return weights, hn_params, emb_params, self.local_sample_number, server_density, device_density

--- a/api/distributed/dwnp/README.md
+++ b/api/distributed/dwnp/README.md
@@ -1,0 +1,16 @@
+# DWNP (Device-Wise Federated Network Pruning)
+
+This module integrates DWNP into the distributed FedPruning workflow.
+
+Core ideas implemented:
+
+- A server-side subnet mask and a device-wise subnet mask are generated from a server code and a client id embedding.
+- Local training uses the joint mask, i.e. the intersection of the server and device masks.
+- Device-wise masks are generated inside server-active weights, which keeps the device subnet from selecting channels outside the server subnet.
+- HN updates use a FLOPs-aware objective with task loss, `lambda_reg`, and an optional smoothness term controlled by `hn_smooth_coeff`.
+- `server_flops_retention` and `device_flops_retention` define the target retained FLOPs for the server and device subnetworks.
+- `hn_min_retention` and `hn_max_retention` bound the predicted retention ratios.
+- `hn_stochastic_gate` can switch CNN-mask application to a softer training path, while `dwnp_warmup_rounds` keeps device-wise extra pruning disabled early on.
+- `r_w`, `r_hn`, and `r_theta` control model synchronization, HN local updates, and HN aggregation respectively.
+- Client-server messaging keeps the current model, HN, and embedding parameters aligned across rounds.
+- After the main communication rounds finish, the server can optionally run one final pruning pass controlled by `dwnp_enable_final_prune`, then broadcast the pruned model for the last fine-tuning round.

--- a/api/distributed/dwnp/message_define.py
+++ b/api/distributed/dwnp/message_define.py
@@ -1,0 +1,28 @@
+class MyMessage(object):
+    """message type definition"""
+
+    # server to client
+    MSG_TYPE_S2C_INIT_CONFIG = 1
+    MSG_TYPE_S2C_SYNC_MODEL_TO_CLIENT = 2
+
+    # client to server
+    MSG_TYPE_C2S_SEND_RESULT_TO_SERVER = 3
+
+    MSG_ARG_KEY_TYPE = "msg_type"
+    MSG_ARG_KEY_SENDER = "sender"
+    MSG_ARG_KEY_RECEIVER = "receiver"
+
+    # payload
+    MSG_ARG_KEY_NUM_SAMPLES = "num_samples"
+    MSG_ARG_KEY_MODEL_PARAMS = "model_params"
+    MSG_ARG_KEY_HN_PARAMS = "hn_params"
+    MSG_ARG_KEY_EMB_PARAMS = "emb_params"
+    MSG_ARG_KEY_CLIENT_INDEX = "client_idx"
+
+    MSG_ARG_KEY_ROUND_IDX = "round_idx"
+    MSG_ARG_KEY_TRAIN_HN = "train_hn"
+    MSG_ARG_KEY_SYNC_W = "sync_w"
+    MSG_ARG_KEY_SYNC_HN = "sync_hn"
+
+    MSG_ARG_KEY_SERVER_DENSITY = "server_density"
+    MSG_ARG_KEY_DEVICE_DENSITY = "device_density"

--- a/api/distributed/dwnp/my_model_trainer_classification.py
+++ b/api/distributed/dwnp/my_model_trainer_classification.py
@@ -1,0 +1,344 @@
+import torch
+from torch import nn
+
+try:
+    from core.trainer.model_trainer import ModelTrainer
+except ImportError:
+    from FedPruning.core.trainer.model_trainer import ModelTrainer
+
+
+class DeviceWiseHyperNetwork(nn.Module):
+    def __init__(self, client_num_in_total, num_sparse_layers, emb_dim=32, hidden_dim=64):
+        super().__init__()
+        self.client_embeddings = nn.Embedding(client_num_in_total + 1, emb_dim)
+        self.mlp = nn.Sequential(
+            nn.Linear(emb_dim, hidden_dim),
+            nn.ReLU(inplace=True),
+            nn.Linear(hidden_dim, num_sparse_layers),
+        )
+
+    def _gumbel_sigmoid(self, logits, temperature=1.0, stochastic=False, hard=False):
+        temperature = max(float(temperature), 1e-6)
+
+        if stochastic:
+            eps = 1e-10
+            uniform = torch.rand_like(logits)
+            logistic_noise = torch.log(uniform + eps) - torch.log(1.0 - uniform + eps)
+            y_soft = torch.sigmoid((logits + logistic_noise) / temperature)
+        else:
+            y_soft = torch.sigmoid(logits / temperature)
+
+        if hard:
+            y_hard = (y_soft >= 0.5).to(y_soft.dtype)
+            # Straight-through estimator: hard in forward, soft in backward.
+            return y_hard - y_soft.detach() + y_soft
+        return y_soft
+
+    def forward(self, client_codes, temperature=1.0, stochastic=False, hard=False):
+        emb = self.client_embeddings(client_codes)
+        logits = self.mlp(emb)
+        return self._gumbel_sigmoid(
+            logits,
+            temperature=temperature,
+            stochastic=stochastic,
+            hard=hard,
+        )
+
+
+class MyModelTrainer(ModelTrainer):
+    def __init__(self, model, args=None):
+        super().__init__(model, args)
+        self.args = args
+
+        self.sparse_layer_names = list(self.model.mask_dict.keys())
+        num_sparse_layers = len(self.sparse_layer_names)
+        self.server_mask_dict = {k: v.detach().clone() for k, v in self.model.mask_dict.items()}
+        self.device_mask_cache = dict()
+
+        emb_dim = getattr(args, "hn_embedding_dim", 32)
+        hidden_dim = getattr(args, "hn_hidden_dim", 64)
+        self.hypernet = DeviceWiseHyperNetwork(
+            args.client_num_in_total,
+            num_sparse_layers,
+            emb_dim=emb_dim,
+            hidden_dim=hidden_dim,
+        )
+
+    def get_model(self):
+        return self.model
+
+    def get_model_params(self):
+        return self.model.cpu().state_dict()
+
+    def set_model_params(self, model_parameters):
+        self.model.load_state_dict(model_parameters, strict=False)
+
+    def get_hypernet_params(self):
+        state = self.hypernet.cpu().state_dict()
+        return {k: v for k, v in state.items() if k != "client_embeddings.weight"}
+
+    def set_hypernet_params(self, hn_parameters):
+        current = self.hypernet.state_dict()
+        for k, v in hn_parameters.items():
+            if k in current and k != "client_embeddings.weight":
+                current[k] = v
+        self.hypernet.load_state_dict(current, strict=False)
+
+    def get_dynamic_emb_params(self):
+        return {"client_embeddings.weight": self.hypernet.client_embeddings.weight.detach().cpu()}
+
+    def set_dynamic_emb_params(self, emb_parameters):
+        if "client_embeddings.weight" in emb_parameters:
+            self.hypernet.client_embeddings.weight.data.copy_(emb_parameters["client_embeddings.weight"])
+
+    def build_server_mask(self, device, round_idx=None):
+        self.model.to(device)
+        self.hypernet.to(device)
+
+        min_r = getattr(self.args, "hn_min_retention", 0.05)
+        max_r = getattr(self.args, "hn_max_retention", 1.0)
+        temperature = getattr(self.args, "hn_temperature", 0.5)
+        use_hn_mask = bool(getattr(self.args, "use_hn_server_mask", False)) or bool(
+            getattr(self.args, "dwnp_enable_final_prune", 1)
+        )
+
+        if use_hn_mask:
+            server_code = torch.tensor([0], dtype=torch.long, device=device)
+            raw_server_ratio = self.hypernet(
+                server_code,
+                temperature=temperature,
+                stochastic=False,
+                hard=False,
+            ).squeeze(0)
+            server_ratio = min_r + (max_r - min_r) * raw_server_ratio
+            return self._ratios_to_masks(server_ratio)
+
+        return {k: v.detach().clone().to(device) for k, v in self.server_mask_dict.items()}
+
+    def apply_server_pruning(self, device, round_idx=None):
+        server_mask = self.build_server_mask(device, round_idx=round_idx)
+        self.model.mask_dict = server_mask
+        self.model.apply_mask()
+        return server_mask
+
+    def _build_single_mask(self, weights, retain_ratio):
+        flat = weights.detach().abs().view(-1)
+        k = max(1, int(retain_ratio * flat.numel()))
+        if k >= flat.numel():
+            return torch.ones_like(weights, dtype=weights.dtype, device=weights.device)
+        threshold = torch.topk(flat, k, largest=True).values.min()
+        return (weights.detach().abs() >= threshold).to(weights.dtype)
+
+    def _build_single_mask_with_base(self, weights, retain_ratio, base_mask):
+        base_mask = base_mask.to(weights.device)
+        active_idx = (base_mask.view(-1) > 0.5).nonzero(as_tuple=False).view(-1)
+        if active_idx.numel() == 0:
+            return torch.ones_like(base_mask, dtype=weights.dtype, device=weights.device)
+
+        active_w = weights.detach().abs().view(-1)[active_idx]
+        k = max(1, int(retain_ratio * active_idx.numel()))
+        k = min(k, active_idx.numel())
+
+        top_idx = torch.topk(active_w, k, largest=True).indices
+        chosen = active_idx[top_idx]
+
+        out = torch.ones_like(base_mask, dtype=weights.dtype, device=weights.device).view(-1)
+        out[active_idx] = 0.0
+        out[chosen] = 1.0
+        return out.view_as(base_mask)
+
+    def _ratios_to_masks(self, ratios):
+        mask_dict = dict()
+        named_params = dict(self.model.model.named_parameters())
+        for idx, name in enumerate(self.sparse_layer_names):
+            param = named_params[name]
+            mask_dict[name] = self._build_single_mask(param, ratios[idx].item())
+        return mask_dict
+
+    def _ratios_to_device_masks(self, ratios, server_mask_dict):
+        mask_dict = dict()
+        named_params = dict(self.model.model.named_parameters())
+        for idx, name in enumerate(self.sparse_layer_names):
+            param = named_params[name]
+            base_mask = server_mask_dict[name]
+            mask_dict[name] = self._build_single_mask_with_base(param, ratios[idx].item(), base_mask)
+        return mask_dict
+
+    def _density(self, mask_dict):
+        remain, total = 0.0, 0.0
+        for name in self.sparse_layer_names:
+            m = mask_dict[name]
+            remain += float(m.sum().item())
+            total += float(m.numel())
+        return remain / max(total, 1.0)
+
+    def _smoothness_penalty(self, gates):
+        if gates.numel() <= 1:
+            return torch.tensor(0.0, device=gates.device)
+        return (gates[1:] - gates[:-1]).pow(2).mean()
+
+    def prepare_joint_mask(self, client_index, round_idx, device, args):
+        self.model.to(device)
+        self.hypernet.to(device)
+
+        min_r = getattr(args, "hn_min_retention", 0.05)
+        max_r = getattr(args, "hn_max_retention", 1.0)
+        warmup_rounds = getattr(args, "dwnp_warmup_rounds", 0)
+        temperature = getattr(args, "hn_temperature", 0.5)
+        stochastic_gate = bool(getattr(args, "hn_stochastic_gate", 0))
+
+        server_code = torch.tensor([0], dtype=torch.long, device=device)
+        device_code = torch.tensor([int(client_index) + 1], dtype=torch.long, device=device)
+
+        raw_server_ratio = self.hypernet(
+            server_code,
+            temperature=temperature,
+            stochastic=stochastic_gate,
+            hard=False,
+        ).squeeze(0)
+        raw_device_ratio = self.hypernet(
+            device_code,
+            temperature=temperature,
+            stochastic=stochastic_gate,
+            hard=False,
+        ).squeeze(0)
+
+        server_ratio = min_r + (max_r - min_r) * raw_server_ratio
+        device_ratio = min_r + (max_r - min_r) * raw_device_ratio
+
+        if getattr(args, "use_hn_server_mask", False):
+            server_mask = self._ratios_to_masks(server_ratio)
+            self.server_mask_dict = {k: v.detach().clone() for k, v in server_mask.items()}
+        else:
+            server_mask = {k: v.detach().clone().to(device) for k, v in self.server_mask_dict.items()}
+
+        if round_idx is not None and round_idx < warmup_rounds:
+            device_mask = {k: torch.ones_like(v, device=device) for k, v in server_mask.items()}
+        else:
+            device_mask = self._ratios_to_device_masks(device_ratio, server_mask)
+
+        self.device_mask_cache[int(client_index)] = {k: v.detach().clone() for k, v in device_mask.items()}
+
+        joint_mask = dict()
+        for name in self.sparse_layer_names:
+            joint_mask[name] = (server_mask[name] * device_mask[name]).to(device)
+
+        self.model.mask_dict = joint_mask
+        self.model.apply_mask()
+
+        server_density = self._density(server_mask)
+        device_density = self._density(joint_mask)
+        return server_density, device_density
+
+    def train(self, train_data, device, args):
+        model = self.model
+
+        model.to(device)
+        model.train()
+
+        criterion = nn.CrossEntropyLoss().to(device)
+        if args.client_optimizer == "sgd":
+            optimizer = torch.optim.SGD(filter(lambda p: p.requires_grad, self.model.parameters()), lr=args.lr)
+        else:
+            optimizer = torch.optim.Adam(
+                filter(lambda p: p.requires_grad, self.model.parameters()),
+                lr=args.lr,
+                weight_decay=args.wd,
+                amsgrad=True,
+            )
+
+        for _ in range(args.epochs):
+            for x, labels in train_data:
+                x, labels = x.to(device), labels.to(device)
+                model.zero_grad()
+                log_probs = model(x)
+                loss = criterion(log_probs, labels)
+                loss.backward()
+                optimizer.step()
+
+    def _sample_batch_task_loss(self, train_data, device):
+        criterion = nn.CrossEntropyLoss().to(device)
+        for x, labels in train_data:
+            x, labels = x.to(device), labels.to(device)
+            with torch.no_grad():
+                logits = self.model(x)
+                return criterion(logits, labels).detach()
+        return torch.tensor(0.0, device=device)
+
+    def train_hypernetwork(self, train_data, client_index, device, args):
+        self.hypernet.to(device)
+        optimizer = torch.optim.Adam(self.hypernet.parameters(), lr=args.hn_lr)
+
+        target_server = torch.tensor(args.server_flops_retention, dtype=torch.float32, device=device)
+        target_device = torch.tensor(args.device_flops_retention, dtype=torch.float32, device=device)
+
+        min_r = getattr(args, "hn_min_retention", 0.05)
+        max_r = getattr(args, "hn_max_retention", 1.0)
+        smooth_coeff = getattr(args, "hn_smooth_coeff", 0.1)
+        task_loss_alpha = getattr(args, "task_loss_alpha", 0.0)
+        temperature = getattr(args, "hn_temperature", 0.5)
+
+        for _ in range(max(1, args.hn_local_epochs)):
+            optimizer.zero_grad()
+            server_code = torch.tensor([0], dtype=torch.long, device=device)
+            device_code = torch.tensor([int(client_index) + 1], dtype=torch.long, device=device)
+
+            raw_server_ratio = self.hypernet(
+                server_code,
+                temperature=temperature,
+                stochastic=True,
+                hard=True,
+            ).squeeze(0)
+            raw_device_ratio = self.hypernet(
+                device_code,
+                temperature=temperature,
+                stochastic=True,
+                hard=True,
+            ).squeeze(0)
+
+            server_ratio = min_r + (max_r - min_r) * raw_server_ratio
+            device_ratio = min_r + (max_r - min_r) * raw_device_ratio
+
+            flops_loss = (server_ratio.mean() - target_server) ** 2 + (device_ratio.mean() - target_device) ** 2
+            smooth_loss = self._smoothness_penalty(server_ratio) + self._smoothness_penalty(device_ratio)
+
+            # Detached task-loss acts as a scalar anchor to modulate regularization strength.
+            task_loss = self._sample_batch_task_loss(train_data, device)
+            reg_loss = args.lambda_reg * flops_loss + smooth_coeff * smooth_loss
+            loss = (1.0 + task_loss_alpha * task_loss) * reg_loss
+            loss.backward()
+            optimizer.step()
+
+    def test(self, test_data, device, args):
+        model = self.model
+
+        model.to(device)
+        model.eval()
+
+        metrics = {
+            "Accuracy": 0,
+            "Loss": 0,
+            "test_total": 0,
+        }
+
+        criterion = nn.CrossEntropyLoss().to(device)
+
+        with torch.no_grad():
+            for _, (x, target) in enumerate(test_data):
+                x = x.to(device)
+                target = target.to(device)
+                pred = model(x)
+                loss = criterion(pred, target)
+                _, predicted = torch.max(pred, -1)
+                correct = predicted.eq(target).sum()
+
+                metrics["Accuracy"] += correct.item()
+                metrics["Loss"] += loss.item() * target.size(0)
+                metrics["test_total"] += target.size(0)
+
+        metrics["Accuracy"] /= max(metrics["test_total"], 1)
+        metrics["Loss"] /= max(metrics["test_total"], 1)
+        return metrics
+
+    def test_on_the_server(self, train_data_local_dict, test_data_local_dict, device, args=None) -> bool:
+        return False

--- a/api/distributed/dwnp/my_model_trainer_language_model.py
+++ b/api/distributed/dwnp/my_model_trainer_language_model.py
@@ -1,0 +1,326 @@
+import numpy as np
+import torch
+from torch import nn
+from transformers import AutoTokenizer
+
+try:
+    from core.trainer.model_trainer import ModelTrainer
+except ImportError:
+    from FedPruning.core.trainer.model_trainer import ModelTrainer
+
+from .my_model_trainer_classification import DeviceWiseHyperNetwork
+
+
+class MyModelTrainer(ModelTrainer):
+    def __init__(self, model, args=None):
+        super().__init__(model, args)
+        self.args = args
+
+        self.tokenizer = AutoTokenizer.from_pretrained("roneneldan/TinyStories")
+        self.tokenizer.pad_token = self.tokenizer.eos_token
+
+        self.sparse_layer_names = list(self.model.mask_dict.keys())
+        num_sparse_layers = len(self.sparse_layer_names)
+        self.server_mask_dict = {k: v.detach().clone() for k, v in self.model.mask_dict.items()}
+        self.device_mask_cache = dict()
+
+        emb_dim = getattr(args, "hn_embedding_dim", 32)
+        hidden_dim = getattr(args, "hn_hidden_dim", 64)
+        self.hypernet = DeviceWiseHyperNetwork(
+            args.client_num_in_total,
+            num_sparse_layers,
+            emb_dim=emb_dim,
+            hidden_dim=hidden_dim,
+        )
+
+    def get_model(self):
+        return self.model
+
+    def get_model_params(self):
+        return self.model.cpu().state_dict()
+
+    def set_model_params(self, model_parameters):
+        self.model.load_state_dict(model_parameters, strict=False)
+
+    def get_hypernet_params(self):
+        state = self.hypernet.cpu().state_dict()
+        return {k: v for k, v in state.items() if k != "client_embeddings.weight"}
+
+    def set_hypernet_params(self, hn_parameters):
+        current = self.hypernet.state_dict()
+        for k, v in hn_parameters.items():
+            if k in current and k != "client_embeddings.weight":
+                current[k] = v
+        self.hypernet.load_state_dict(current, strict=False)
+
+    def get_dynamic_emb_params(self):
+        return {"client_embeddings.weight": self.hypernet.client_embeddings.weight.detach().cpu()}
+
+    def set_dynamic_emb_params(self, emb_parameters):
+        if "client_embeddings.weight" in emb_parameters:
+            self.hypernet.client_embeddings.weight.data.copy_(emb_parameters["client_embeddings.weight"])
+
+    def build_server_mask(self, device, round_idx=None):
+        self.model.to(device)
+        self.hypernet.to(device)
+
+        min_r = getattr(self.args, "hn_min_retention", 0.05)
+        max_r = getattr(self.args, "hn_max_retention", 1.0)
+        temperature = getattr(self.args, "hn_temperature", 0.5)
+        use_hn_mask = bool(getattr(self.args, "use_hn_server_mask", False)) or bool(
+            getattr(self.args, "dwnp_enable_final_prune", 1)
+        )
+
+        if use_hn_mask:
+            server_code = torch.tensor([0], dtype=torch.long, device=device)
+            raw_server_ratio = self.hypernet(
+                server_code,
+                temperature=temperature,
+                stochastic=False,
+                hard=False,
+            ).squeeze(0)
+            server_ratio = min_r + (max_r - min_r) * raw_server_ratio
+            return self._ratios_to_masks(server_ratio)
+
+        return {k: v.detach().clone().to(device) for k, v in self.server_mask_dict.items()}
+
+    def apply_server_pruning(self, device, round_idx=None):
+        server_mask = self.build_server_mask(device, round_idx=round_idx)
+        self.model.mask_dict = server_mask
+        self.model.apply_mask()
+        return server_mask
+
+    def _build_single_mask(self, weights, retain_ratio):
+        flat = weights.detach().abs().view(-1)
+        k = max(1, int(retain_ratio * flat.numel()))
+        if k >= flat.numel():
+            return torch.ones_like(weights, dtype=weights.dtype, device=weights.device)
+        threshold = torch.topk(flat, k, largest=True).values.min()
+        return (weights.detach().abs() >= threshold).to(weights.dtype)
+
+    def _build_single_mask_with_base(self, weights, retain_ratio, base_mask):
+        base_mask = base_mask.to(weights.device)
+        active_idx = (base_mask.view(-1) > 0.5).nonzero(as_tuple=False).view(-1)
+        if active_idx.numel() == 0:
+            return torch.ones_like(base_mask, dtype=weights.dtype, device=weights.device)
+
+        active_w = weights.detach().abs().view(-1)[active_idx]
+        k = max(1, int(retain_ratio * active_idx.numel()))
+        k = min(k, active_idx.numel())
+
+        top_idx = torch.topk(active_w, k, largest=True).indices
+        chosen = active_idx[top_idx]
+
+        out = torch.ones_like(base_mask, dtype=weights.dtype, device=weights.device).view(-1)
+        out[active_idx] = 0.0
+        out[chosen] = 1.0
+        return out.view_as(base_mask)
+
+    def _ratios_to_masks(self, ratios):
+        mask_dict = dict()
+        named_params = dict(self.model.model.named_parameters())
+        for idx, name in enumerate(self.sparse_layer_names):
+            param = named_params[name]
+            mask_dict[name] = self._build_single_mask(param, ratios[idx].item())
+        return mask_dict
+
+    def _ratios_to_device_masks(self, ratios, server_mask_dict):
+        mask_dict = dict()
+        named_params = dict(self.model.model.named_parameters())
+        for idx, name in enumerate(self.sparse_layer_names):
+            param = named_params[name]
+            base_mask = server_mask_dict[name]
+            mask_dict[name] = self._build_single_mask_with_base(param, ratios[idx].item(), base_mask)
+        return mask_dict
+
+    def _density(self, mask_dict):
+        remain, total = 0.0, 0.0
+        for name in self.sparse_layer_names:
+            m = mask_dict[name]
+            remain += float(m.sum().item())
+            total += float(m.numel())
+        return remain / max(total, 1.0)
+
+    def _smoothness_penalty(self, gates):
+        if gates.numel() <= 1:
+            return torch.tensor(0.0, device=gates.device)
+        return (gates[1:] - gates[:-1]).pow(2).mean()
+
+    def prepare_joint_mask(self, client_index, round_idx, device, args):
+        self.model.to(device)
+        self.hypernet.to(device)
+
+        min_r = getattr(args, "hn_min_retention", 0.05)
+        max_r = getattr(args, "hn_max_retention", 1.0)
+        warmup_rounds = getattr(args, "dwnp_warmup_rounds", 20)
+        temperature = getattr(args, "hn_temperature", 0.5)
+        stochastic_gate = bool(getattr(args, "hn_stochastic_gate", 0))
+
+        server_code = torch.tensor([0], dtype=torch.long, device=device)
+        device_code = torch.tensor([int(client_index) + 1], dtype=torch.long, device=device)
+
+        raw_server_ratio = self.hypernet(
+            server_code,
+            temperature=temperature,
+            stochastic=stochastic_gate,
+            hard=False,
+        ).squeeze(0)
+        raw_device_ratio = self.hypernet(
+            device_code,
+            temperature=temperature,
+            stochastic=stochastic_gate,
+            hard=False,
+        ).squeeze(0)
+
+        server_ratio = min_r + (max_r - min_r) * raw_server_ratio
+        device_ratio = min_r + (max_r - min_r) * raw_device_ratio
+
+        if getattr(args, "use_hn_server_mask", False):
+            server_mask = self._ratios_to_masks(server_ratio)
+            self.server_mask_dict = {k: v.detach().clone() for k, v in server_mask.items()}
+        else:
+            server_mask = {k: v.detach().clone().to(device) for k, v in self.server_mask_dict.items()}
+
+        if round_idx is not None and round_idx < warmup_rounds:
+            device_mask = {k: torch.ones_like(v, device=device) for k, v in server_mask.items()}
+        else:
+            device_mask = self._ratios_to_device_masks(device_ratio, server_mask)
+
+        self.device_mask_cache[int(client_index)] = {k: v.detach().clone() for k, v in device_mask.items()}
+
+        joint_mask = dict()
+        for name in self.sparse_layer_names:
+            joint_mask[name] = (server_mask[name] * device_mask[name]).to(device)
+
+        self.model.mask_dict = joint_mask
+        self.model.apply_mask()
+
+        server_density = self._density(server_mask)
+        device_density = self._density(joint_mask)
+        return server_density, device_density
+
+    def train(self, train_data, device, args):
+        model = self.model
+
+        model.to(device)
+        model.train()
+
+        if args.client_optimizer == "sgd":
+            optimizer = torch.optim.SGD(filter(lambda p: p.requires_grad, self.model.parameters()), lr=args.lr)
+        else:
+            optimizer = torch.optim.Adam(
+                filter(lambda p: p.requires_grad, self.model.parameters()),
+                lr=args.lr,
+                weight_decay=args.wd,
+                amsgrad=True,
+            )
+
+        for _ in range(args.epochs):
+            for batch in train_data:
+                tokenized = self.tokenizer(
+                    batch["text"],
+                    padding=True,
+                    return_tensors="pt",
+                    max_length=256,
+                    truncation=True,
+                )["input_ids"].to(device)
+                model.zero_grad()
+                logits, loss = model(tokenized, tokenized)
+                loss.backward()
+                optimizer.step()
+
+    def train_hypernetwork(self, train_data, client_index, device, args):
+        self.hypernet.to(device)
+        optimizer = torch.optim.Adam(self.hypernet.parameters(), lr=args.hn_lr)
+
+        target_server = torch.tensor(args.server_flops_retention, dtype=torch.float32, device=device)
+        target_device = torch.tensor(args.device_flops_retention, dtype=torch.float32, device=device)
+
+        min_r = getattr(args, "hn_min_retention", 0.05)
+        max_r = getattr(args, "hn_max_retention", 1.0)
+
+        smooth_coeff = getattr(args, "hn_smooth_coeff", 0.1)
+        temperature = getattr(args, "hn_temperature", 0.5)
+
+        for _ in range(max(1, args.hn_local_epochs)):
+            optimizer.zero_grad()
+            server_code = torch.tensor([0], dtype=torch.long, device=device)
+            device_code = torch.tensor([int(client_index) + 1], dtype=torch.long, device=device)
+
+            raw_server_ratio = self.hypernet(
+                server_code,
+                temperature=temperature,
+                stochastic=True,
+                hard=True,
+            ).squeeze(0)
+            raw_device_ratio = self.hypernet(
+                device_code,
+                temperature=temperature,
+                stochastic=True,
+                hard=True,
+            ).squeeze(0)
+
+            server_ratio = min_r + (max_r - min_r) * raw_server_ratio
+            device_ratio = min_r + (max_r - min_r) * raw_device_ratio
+
+            flops_loss = (server_ratio.mean() - target_server) ** 2 + (device_ratio.mean() - target_device) ** 2
+            smooth_loss = self._smoothness_penalty(server_ratio) + self._smoothness_penalty(device_ratio)
+            loss = args.lambda_reg * flops_loss + smooth_coeff * smooth_loss
+            loss.backward()
+            optimizer.step()
+
+    def test(self, test_data, device, args):
+        model = self.model
+
+        model.to(device)
+        model.eval()
+
+        metrics = {
+            "Accuracy": 0,
+            "Loss": 0,
+            "Perplexity": 0,
+            "test_total": 0,
+        }
+
+        nlls = []
+        with torch.no_grad():
+            for batch in test_data:
+                tokenized = self.tokenizer(
+                    batch["text"],
+                    padding=True,
+                    return_tensors="pt",
+                    max_length=256,
+                    truncation=True,
+                )["input_ids"].to(device)
+                labels = tokenized[..., 1:].cpu()
+                logits, loss = model(tokenized, tokenized)
+                pred_ids = torch.argmax(logits, dim=-1)[..., :-1].cpu()
+
+                pad_token_id = self.tokenizer.encode(self.tokenizer.pad_token)[0]
+
+                metrics["Loss"] += loss.item() * len(batch["text"])
+                metrics["test_total"] += len(batch["text"])
+
+                for i in range(len(labels)):
+                    hit, total = 0, 0
+                    token_probs = []
+                    for j in range(len(labels[i])):
+                        if labels[i][j] != pad_token_id:
+                            poss = torch.nn.functional.softmax(logits[i][j], dim=-1)
+                            logit = poss[labels[i][j]].item()
+                            token_probs.append(logit)
+                            total += 1
+                            if labels[i][j] == pred_ids[i][j]:
+                                hit += 1
+                    if total > 0:
+                        metrics["Accuracy"] += (hit / total)
+                        ppl = np.exp(-np.sum(np.log(token_probs)) / len(token_probs))
+                        nlls.append(ppl)
+
+        metrics["Loss"] /= max(metrics["test_total"], 1)
+        metrics["Accuracy"] /= max(metrics["test_total"], 1)
+        metrics["Perplexity"] = float(np.mean(nlls)) if len(nlls) > 0 else 0.0
+        return metrics
+
+    def test_on_the_server(self, train_data_local_dict, test_data_local_dict, device, args=None) -> bool:
+        return False

--- a/api/distributed/dwnp/utils.py
+++ b/api/distributed/dwnp/utils.py
@@ -1,0 +1,27 @@
+import os
+
+import numpy as np
+import torch
+
+
+def transform_list_to_tensor(model_params_list):
+    for k in model_params_list.keys():
+        model_params_list[k] = torch.from_numpy(np.asarray(model_params_list[k])).float()
+    return model_params_list
+
+
+def transform_tensor_to_list(model_params):
+    for k in model_params.keys():
+        model_params[k] = model_params[k].detach().cpu().numpy().tolist()
+    return model_params
+
+
+def post_complete_message_to_sweep_process(args):
+    pipe_path = "./tmp/fedml"
+    os.system("mkdir ./tmp/; touch ./tmp/fedml")
+    if not os.path.exists(pipe_path):
+        os.mkfifo(pipe_path)
+    pipe_fd = os.open(pipe_path, os.O_WRONLY)
+
+    with os.fdopen(pipe_fd, "w") as pipe:
+        pipe.write("training is finished! \n%s\n" % (str(args)))

--- a/experiments/dwnp/README.MD
+++ b/experiments/dwnp/README.MD
@@ -1,0 +1,53 @@
+# DWNP Experiment
+
+## Quick Start
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1,2,3 sh run_dwnp_distributed_pytorch.sh resnet18 cifar10 100 10 200 5 0.5 0.001 \
+  --r_w 1 --r_hn 5 --r_theta 2 \
+  --server_flops_retention 0.5 --device_flops_retention 0.9 --lambda_reg 1.0 \
+  --dwnp_warmup_rounds 5 --hn_min_retention 0.6 --hn_max_retention 1.0 \
+  --hn_smooth_coeff 0.1 --task_loss_alpha 0.0 --hn_temperature 0.5 --hn_stochastic_gate 0 \
+  --dwnp_enable_final_prune 1 \
+  --partition_alpha 0.5 --frequency_of_the_test 5
+```
+
+Example command used in this repo (wandb disabled):
+
+```bash
+CUDA_VISIBLE_DEVICES=4,5,6,7 bash
+run_dwnp_distributed_pytorch.sh resnet18 cifar10 100 10 200 5 1.0 0.05
+```
+
+## Usage
+
+```bash
+CUDA_VISIBLE_DEVICES=[gpus] sh run_dwnp_distributed_pytorch.sh [model] [dataset] [client_num_in_total] [client_num_per_round] [comm_round] [epochs] [target_density] [lr] {optional args}
+```
+
+Important optional args:
+
+- `--r_w`: model communication interval.
+- `--r_hn`: hypernetwork local training frequency.
+- `--r_theta`: hypernetwork communication interval.
+- `--server_flops_retention`: target FLOPs retention for server mask.
+- `--device_flops_retention`: target FLOPs retention for device mask.
+- `--lambda_reg`: coefficient for FLOPs regularization.
+- `--hn_smooth_coeff`: optional smoothness penalty for neighboring HN outputs.
+- `--task_loss_alpha`: optional weight for the detached task loss term in HN training.
+- `--dwnp_warmup_rounds`: warmup rounds before enabling device-wise extra pruning.
+- `--hn_min_retention`, `--hn_max_retention`: lower and upper bounds for the predicted retention ratios.
+- `--hn_lr`: hypernetwork learning rate.
+- `--hn_local_epochs`: local epochs when training hypernetwork.
+- `--hn_embedding_dim`, `--hn_hidden_dim`: hypernetwork architecture.
+- `--hn_temperature`: ST Gumbel-Sigmoid temperature.
+- `--hn_stochastic_gate`: whether to keep the CNN-side mask application stochastic during training.
+- `--use_hn_server_mask`: whether the server-side mask is updated from the HN during the main training rounds.
+- `--dwnp_enable_final_prune`: whether to run one final server-side prune and broadcast the pruned model before the last fine-tuning round.
+
+Notes:
+
+- The current implementation keeps the original distributed structure used by the other FedPruning methods: server aggregation, client-local training, and periodic synchronization remain unchanged.
+- The final pruning round is still part of the same distributed loop; it does not add a new standalone script or message schema.
+- The final server-side pruning pass is exported with deterministic gates (non-stochastic) for stable reproduction and deployment.
+- `hn_stochastic_gate` controls stochasticity during CNN-side joint-mask preparation, while HN training uses ST Gumbel-Sigmoid sampling.

--- a/experiments/dwnp/gpu_mapping.yaml
+++ b/experiments/dwnp/gpu_mapping.yaml
@@ -1,0 +1,4 @@
+# Please check "GPU_MAPPING.md" to see how to define the topology
+
+mapping_default:
+    four_gpu: [3, 3, 3, 2]

--- a/experiments/dwnp/main_dwnp.py
+++ b/experiments/dwnp/main_dwnp.py
@@ -1,0 +1,271 @@
+import argparse
+import logging
+import os
+import random
+import socket
+import sys
+
+import numpy as np
+import psutil
+import setproctitle
+import torch
+import wandb
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.getcwd(), "./../../../")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.getcwd(), "./../../")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.getcwd(), "")))
+
+from api.distributed.utils.gpu_mapping import mapping_processes_to_gpu_device_from_yaml_file
+
+from api.data_preprocessing.cifar10.data_loader import load_partition_data_cifar10
+from api.data_preprocessing.cifar100.data_loader import load_partition_data_cifar100
+from api.data_preprocessing.cinic10.data_loader import load_partition_data_cinic10
+from api.data_preprocessing.svhn.data_loader import load_partition_data_svhn
+from api.data_preprocessing.tinystories.data_loader import load_partition_data_tinystories
+from api.data_preprocessing.tinyimagenet.data_loader import load_partition_data_tiny
+
+from api.model.cv.resnet_gn import resnet18 as resnet18_gn
+from api.model.cv.mobilenet import mobilenet
+from api.model.cv.resnet import resnet18, resnet56
+from api.model.nlp.gpt2 import GPT2Model, GPT2Config
+from torchvision.models import mobilenet_v3_small as MobileNetV3
+from torchvision.models import efficientnet_v2_s as EfficientNetV2
+from torchvision.models import mnasnet0_75 as MNASNet
+from torchvision.models import shufflenet_v2_x0_5 as ShuffleNet
+from torchvision.models import squeezenet1_1 as SqueezeNet
+from torchvision.models import swin_t as SwinT
+from torchvision.models import vit_b_16 as ViT
+
+from api.distributed.dwnp.DWNPAPI import FedML_DWNP_distributed, FedML_init
+from api.pruning.model_pruning import SparseModel
+
+
+def add_args(parser):
+    parser.add_argument("--model", type=str, default="resnet56", metavar="N", help="neural network used in training")
+    parser.add_argument("--dataset", type=str, default="cifar10", metavar="N", help="dataset used for training")
+
+    parser.add_argument("--partition_alpha", type=float, default=0.5, metavar="PA", help="partition alpha")
+    parser.add_argument("--partition_method", type=str, default="hetero", metavar="N", help="partition method")
+
+    parser.add_argument("--client_num_in_total", type=int, default=10, metavar="NN", help="number of clients")
+    parser.add_argument("--client_num_per_round", type=int, default=10, metavar="NN", help="clients per round")
+
+    parser.add_argument("--batch_size", type=int, default=64, metavar="N", help="input batch size")
+    parser.add_argument("--epochs", type=int, default=5, metavar="EP", help="local epochs")
+    parser.add_argument("--comm_round", type=int, default=100, help="communication rounds")
+
+    parser.add_argument("--lr", type=float, default=0.001, metavar="LR", help="learning rate")
+    parser.add_argument("--wd", type=float, default=0.001, help="weight decay")
+    parser.add_argument("--client_optimizer", type=str, default="sgd", help="sgd or adam")
+
+    parser.add_argument("--frequency_of_the_test", type=int, default=5, help="test frequency")
+    parser.add_argument("--num_eval", type=int, default=128, help="validation sample count, -1 uses full test set")
+
+    parser.add_argument("--pruning_strategy", type=str, default="ERK_magnitude", help="sparsity strategy")
+    parser.add_argument("--target_density", type=float, default=0.5, help="base sparse model density")
+
+    parser.add_argument("--r_w", type=int, default=1, help="model communication interval")
+    parser.add_argument("--r_hn", type=int, default=5, help="hypernetwork local update frequency")
+    parser.add_argument("--r_theta", type=int, default=1, help="hypernetwork communication interval")
+
+    parser.add_argument("--server_flops_retention", type=float, default=0.5, help="server-side FLOPs retention target")
+    parser.add_argument("--device_flops_retention", type=float, default=0.9, help="device-side FLOPs retention target")
+    parser.add_argument("--lambda_reg", type=float, default=1.0, help="FLOPs regularization coefficient")
+    parser.add_argument("--hn_smooth_coeff", type=float, default=0.1, help="smoothness coefficient for HN output")
+    parser.add_argument("--dwnp_warmup_rounds", type=int, default=0, help="warmup rounds before enabling device-wise extra pruning")
+    parser.add_argument("--use_hn_server_mask", type=int, default=0, help="whether to let HN update server mask")
+
+    parser.add_argument("--hn_lr", type=float, default=0.0005, help="hypernetwork learning rate")
+    parser.add_argument("--hn_local_epochs", type=int, default=1, help="local epochs for hypernetwork update")
+    parser.add_argument("--hn_subset_batches", type=int, default=2, help="subset batches for HN local objective")
+    parser.add_argument("--hn_embedding_dim", type=int, default=32, help="embedding dim in hypernetwork")
+    parser.add_argument("--hn_hidden_dim", type=int, default=64, help="hidden dim in hypernetwork")
+    parser.add_argument("--hn_temperature", type=float, default=0.5, help="ST gumbel-sigmoid temperature")
+    parser.add_argument("--hn_stochastic_gate", type=int, default=0, help="whether to sample stochastic gates during CNN updates")
+    parser.add_argument("--hn_min_retention", type=float, default=0.6, help="minimum per-layer retention predicted by HN")
+    parser.add_argument("--hn_max_retention", type=float, default=1.0, help="maximum per-layer retention predicted by HN")
+    parser.add_argument("--task_loss_alpha", type=float, default=0.0, help="weight of detached task loss in HN objective")
+    parser.add_argument("--dwnp_enable_final_prune", type=int, default=1, help="whether to run a final server-side prune and finetune round")
+
+    parser.add_argument("--dataset_ratio", type=float, default=0.05, metavar="PA", help="subset ratio for tinystories")
+    parser.add_argument("--nlp_hidden_size", type=int, default=256, metavar="N", help="hidden size for GPT2")
+
+    parser.add_argument("--gpu_mapping_key", type=str, default="mapping_default", help="gpu mapping key")
+    parser.add_argument("--gpu_mapping_file", type=str, default="gpu_mapping.yaml", help="gpu mapping file")
+    parser.add_argument("--gpu_server_num", type=int, default=1, help="gpu server num")
+    parser.add_argument("--gpu_num_per_server", type=int, default=4, help="gpu num per server")
+
+    parser.add_argument("--is_mobile", type=int, default=1, help="whether running on FedML-Mobile server")
+    parser.add_argument("--backend", type=str, default="MPI", help="backend")
+    parser.add_argument("--data_dir", type=str, default=None, help="data directory")
+    parser.add_argument("--ci", type=int, default=0, help="CI")
+
+    args = parser.parse_args()
+    return args
+
+
+def load_data(args, dataset_name):
+    if args.data_dir is None:
+        if dataset_name == "tinyimagenet":
+            args.data_dir = "./../../data/Tiny-ImageNet"
+        else:
+            args.data_dir = f"./../../data/{dataset_name}"
+
+    if dataset_name == "tinystories":
+        dataset_tuple = load_partition_data_tinystories(
+            args.partition_method,
+            args.partition_alpha,
+            args.client_num_in_total,
+            args.batch_size,
+            args.dataset_ratio,
+        )
+    elif dataset_name == "tinyimagenet":
+        dataset_tuple = load_partition_data_tiny(
+            args.data_dir,
+            args.partition_method,
+            args.partition_alpha,
+            args.client_num_in_total,
+            args.batch_size,
+        )
+    else:
+        if dataset_name == "cifar10":
+            data_loader = load_partition_data_cifar10
+        elif dataset_name == "cifar100":
+            data_loader = load_partition_data_cifar100
+        elif dataset_name == "cinic10":
+            data_loader = load_partition_data_cinic10
+        elif dataset_name == "svhn":
+            data_loader = load_partition_data_svhn
+        else:
+            data_loader = load_partition_data_cifar10
+
+        dataset_tuple = data_loader(
+            args.dataset,
+            args.data_dir,
+            args.partition_method,
+            args.partition_alpha,
+            args.client_num_in_total,
+            args.batch_size,
+        )
+
+    return dataset_tuple
+
+
+def create_model(args, model_name, output_dim):
+    logging.info("create_model. model_name = %s, output_dim = %s", model_name, output_dim)
+    model = None
+    if model_name == "resnet18_gn":
+        model = resnet18_gn(num_classes=output_dim)
+    if model_name == "resnet18":
+        model = resnet18(class_num=output_dim)
+    elif model_name == "resnet56":
+        model = resnet56(class_num=output_dim)
+    elif model_name == "mobilenet":
+        model = mobilenet(class_num=output_dim)
+    elif model_name == "mobilenetv3":
+        model = MobileNetV3(num_classes=output_dim)
+    elif model_name == "efficientnet":
+        model = EfficientNetV2(num_classes=output_dim)
+    elif model_name == "shufflenet":
+        model = ShuffleNet(num_classes=output_dim)
+    elif model_name == "squeezenet":
+        model = SqueezeNet(num_classes=output_dim)
+    elif model_name == "swint":
+        model = SwinT(num_classes=output_dim)
+    elif model_name == "vit":
+        model = ViT(image_size=32, num_classes=output_dim)
+    elif model_name == "mnasnet":
+        model = MNASNet(num_classes=output_dim)
+    elif model_name == "gpt2":
+        GPT2Config["hidden_size"] = args.nlp_hidden_size
+        model = GPT2Model(GPT2Config)
+        logging.info("number of parameters: %.2fM", model.get_num_params() / 1e6)
+    else:
+        raise Exception(f"{model_name} is not found !")
+    return model
+
+
+if __name__ == "__main__":
+    if sys.platform == "darwin":
+        os.environ["KMP_DUPLICATE_LIB_OK"] = "True"
+
+    comm, process_id, worker_number = FedML_init()
+
+    parser = argparse.ArgumentParser()
+    args = add_args(parser)
+    logging.info(args)
+
+    str_process_name = "DWNP (distributed):" + str(process_id)
+    setproctitle.setproctitle(str_process_name)
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format=str(process_id) + " - %(asctime)s %(filename)s[line:%(lineno)d] %(levelname)s %(message)s",
+        datefmt="%a, %d %b %Y %H:%M:%S",
+    )
+
+    hostname = socket.gethostname()
+    logging.info(
+        "#############process ID = "
+        + str(process_id)
+        + ", host name = "
+        + hostname
+        + "########"
+        + ", process ID = "
+        + str(os.getpid())
+        + ", process Name = "
+        + str(psutil.Process(os.getpid()))
+    )
+
+    if process_id == 0:
+        wandb.init(
+            project="FedPruning",
+            name="DWNP_" + args.dataset + "_" + args.model,
+            config=args,
+        )
+
+    random.seed(0)
+    np.random.seed(0)
+    torch.manual_seed(0)
+    torch.cuda.manual_seed_all(0)
+
+    logging.info("process_id = %d, size = %d", process_id, worker_number)
+    device = mapping_processes_to_gpu_device_from_yaml_file(
+        process_id,
+        worker_number,
+        args.gpu_mapping_file,
+        args.gpu_mapping_key,
+    )
+
+    dataset = load_data(args, args.dataset)
+
+    [
+        train_data_num,
+        test_data_num,
+        train_data_global,
+        test_data_global,
+        train_data_local_num_dict,
+        train_data_local_dict,
+        test_data_local_dict,
+        class_num,
+    ] = dataset
+
+    args.num_classes = class_num
+
+    inner_model = create_model(args, model_name=args.model, output_dim=dataset[7])
+    model = SparseModel(inner_model, target_density=args.target_density, strategy=args.pruning_strategy)
+
+    FedML_DWNP_distributed(
+        process_id,
+        worker_number,
+        device,
+        comm,
+        model,
+        train_data_num,
+        train_data_global,
+        test_data_global,
+        train_data_local_num_dict,
+        train_data_local_dict,
+        test_data_local_dict,
+        args,
+    )

--- a/experiments/dwnp/run_dwnp_distributed_pytorch.sh
+++ b/experiments/dwnp/run_dwnp_distributed_pytorch.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+MODEL=$1
+DATASET=$2
+CLIENT_NUM=$3
+WORKER_NUM=$4
+ROUND=$5
+EPOCH=$6
+DENSITY=$7
+LR=$8
+
+PROCESS_NUM=`expr $WORKER_NUM + 1`
+echo $PROCESS_NUM
+
+hostname > mpi_host_file
+
+command="mpirun -np $PROCESS_NUM -hostfile ./mpi_host_file python3 ./main_dwnp.py \
+  --gpu_mapping_file gpu_mapping.yaml \
+  --gpu_mapping_key mapping_default \
+  --model $MODEL \
+  --dataset $DATASET \
+  --client_num_in_total $CLIENT_NUM \
+  --client_num_per_round $WORKER_NUM \
+  --comm_round $ROUND \
+  --epochs $EPOCH \
+  --lr $LR \
+  --target_density $DENSITY"
+
+shift 8
+
+for arg in "$@"; do
+  command="$command $arg"
+done
+
+eval $command


### PR DESCRIPTION
## Summary
This PR adds a new federated pruning method: **DWNP (Device-Wise Federated Network Pruning)**.

Main idea:
- Learn server-side and device-side subnetworks.
- Use embedding + hypernetwork to generate pruning gates.
- Train CNN weights and hypernetwork in alternating stages.

## What is included
- New DWNP distributed pipeline (server/client/trainer/aggregator).
- Hypernetwork + embedding based mask generation.
- Device-specific subnetworks with server-side constraint.
- DWNP experiment entry and run scripts.

## CLI / Config
Added DWNP-related args such as:
- communication intervals: `r_w`, `r_hn`, `r_theta`
- retention targets: `server_flops_retention`, `device_flops_retention`
- HN params: embedding dim, hidden dim, temperature, warmup rounds, etc.

## Validation
I ran DWNP training on **dataset: cifar10, model: resnet18**, and confirmed:
- Training runs end-to-end without runtime errors.
- Test/Loss trends down.
- Test/Accuracy trends up and reaches around **0.6**.

## Compatibility
- Existing methods are unchanged.
- No breaking API changes for other experiment entrypoints.
